### PR TITLE
Use Rails TaggedLogging when available

### DIFF
--- a/lib/tracer_bullets.rb
+++ b/lib/tracer_bullets.rb
@@ -5,11 +5,22 @@ module TracerBullets
   module Methods
     def tracer_bullet
       if Rails.env.development?
-        Rails.logger.debug( "Elapsed: #{((Time.now - @tracer_bullet_start_time)*1000).to_i}ms #{caller(0)[1]}" ) 
+        _tracer_bullets_log( "Elapsed: #{((Time.now - @tracer_bullet_start_time)*1000).to_i}ms #{caller(0)[1]}" )
         @tracer_bullet_start_time = Time.now
       end
     end
     alias_method :tb, :tracer_bullet
+
+    private
+
+    def _tracer_bullets_log(msg)
+      log = Rails.logger
+      if defined?(ActiveSupport::TaggedLogging)
+        log.tagged("TracerBullets") { |l| l.debug(msg) }
+      else
+        log.debug(msg)
+      end
+    end
   end
 
   module Controller


### PR DESCRIPTION
Hi n8, saw your blog post from Hacker News and I like the idea of your gem. When I looked at it, using TaggedLogging was my first idea so this is a small change that adds support for the Rails 3.2+ TaggedLogging helper when available. Let me know what you think!
