### PR TITLE
Rack compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,50 +9,71 @@ Tracer Bullet is also a private investigator, an alter ego of Calvin in the comi
 
 -----------------------
 
-The *Tracer Bullets* gem makes studying the performance of your Rails app from its development log file a lot easier.
+The *Tracer Bullets* gem makes studying the performance of your Rails or Rack app from its development log file a lot easier.
 
 
 ## Background
 
-Performance tuning a Rails app is still pretty damn hard. There are great tools out there like New Relic, and even Rails own performance tests, but still, I find areas where I'm tearing my hair out looking for slow bits. 
+Performance tuning a Rails app is still pretty damn hard. There are great tools out there like New Relic, and even Rails own performance tests, but still, I find areas where I'm tearing my hair out looking for slow bits.
 
-On the Obama re-election campaign, I did a ton of performance engineering, and the tool that helped me out the most was simply something I built to add "tracer bullets" to my code. These bullets were just method calls to log the current location of the program and how much time had elapsed since the last time it was called. 
+On the Obama re-election campaign, I did a ton of performance engineering, and the tool that helped me out the most was simply something I built to add "tracer bullets" to my code. These bullets were just method calls to log the current location of the program and how much time had elapsed since the last time it was called.
 
-I keep finding myself reinventing this same type of performance logging tool to solve performance bottlenecks in things I work on today, like **[Draft](http://draftin.com) (an app to help people [write better](http://draftin.com))** 
- 
+I keep finding myself reinventing this same type of performance logging tool to solve performance bottlenecks in things I work on today, like **[Draft](http://draftin.com) (an app to help people [write better](http://draftin.com))**
+
 So here's a really simple version I made for everyone to use. It gives you a method to call:
 
 ```ruby
 tracer_bullet
 ```
 
-in your controllers and views. When you request an action from your Rails app, that method will log the elapsed time since the last time it was called as well as its location in your controller or view. 
+in your controllers and views. When you request an action from your Rails app, that method will log the elapsed time since the last time it was called as well as its location in your controller or view.
 
 As you intermix them with your code, you'll notice it becomes a lot easier to narrow your focus on the slow parts of the request.
 
 ## Syntax
 
-In a controller, just call the method:  
+In a controller, just call the method:
 
 ```ruby
 tracer_bullet
 ```
 
-In a view, call it with: 
+In a view, call it with:
 
 ```erb
 <%= tracer_bullet %>
 ```
 
-To save keystrokes, you can also use the alias: 
+To save keystrokes, you can also use the alias:
 
 ```ruby
 tb
 ```
 
+To use with Rack specifically, ensure you tell it to use the `TracerBullets::Middleware` class. Then the `tracer_bullet` or `tb` methods should be accessible in your Rack app:
+
+```ruby
+# dummy_rack_app.rb
+require "./lib/tracer_bullets"
+
+class DummyRackApp
+  def call(env)
+    tracer_bullet
+    [200, {'Content-Type' => 'text/plain'}, ["Hello world!"]]
+  end
+end
+
+# config.ru
+require "tracer_bullets/middleware"
+require "./dummy_rack_app"
+
+use TracerBullets::Middleware
+run DummyRackApp.new
+```
+
 ## Example Log
 
-The output of your development.log file will look like: 
+The output of your development.log file will look like:
 
 ```
 Elapsed: 4.505ms /Users/nate/git/afternoon/app/views/documents/edit.html.erb:482
@@ -62,9 +83,9 @@ Elapsed: 4.505ms /Users/nate/git/afternoon/app/views/documents/edit.html.erb:482
 Elapsed: 7.096ms /Users/nate/git/afternoon/app/views/documents/edit.html.erb:539
 ```
 
-Letting you know that between line 482 of my edit.html.erb file and line 539, 7ms had passed. That isn't my slow section. 
+Letting you know that between line 482 of my edit.html.erb file and line 539, 7ms had passed. That isn't my slow section.
 
-Now if it was obviously a lot slower like 200ms, I might take a good look at what's happening in that block of code. 
+Now if it was obviously a lot slower like 200ms, I might take a good look at what's happening in that block of code.
 
 ## Development Only
 
@@ -74,11 +95,11 @@ These traces only run in Development mode. So you can leave them in your code if
 Installation
 ------------
 
-1) Add 'tracer_bullets' to your Gemfile. Probably best to just add it to your development group: 
+1) Add 'tracer_bullets' to your Gemfile. Probably best to just add it to your development group:
 
 ```
-group :development do 
-gem 'tracer_bullets'
+group :development do
+  gem 'tracer_bullets'
 end
 ```
 
@@ -103,4 +124,4 @@ Feedback
 
 -----------
 
-P.S. [**I'd love to meet you on Twitter: here**](http://twitter.com/natekontny). 
+P.S. [**I'd love to meet you on Twitter: here**](http://twitter.com/natekontny).

--- a/lib/tracer_bullets.rb
+++ b/lib/tracer_bullets.rb
@@ -17,6 +17,8 @@ module TracerBullets
         @tracer_bullet_start_time = Time.now
       end
     end
+    alias_method :tb, :tracer_bullet
+
   end
 end
 

--- a/lib/tracer_bullets.rb
+++ b/lib/tracer_bullets.rb
@@ -1,61 +1,23 @@
 require "tracer_bullets/version"
 
 module TracerBullets
+  module TracerMethods
+    def setup_tracer_bullet_start_time
+      @app ||= self
+      @app.instance_variable_set :@tracer_bullet_start_time, Time.now
+    end
 
-  module Methods
+    def trace_logger
+      @logger ||= TraceLogger.new (defined?(Rails) ? RailsLogger : RackLogger)
+    end
+
     def tracer_bullet
-      if Rails.env.development?
-        _tracer_bullets_log( "Elapsed: #{((Time.now - @tracer_bullet_start_time)*1000).to_i}ms #{caller(0)[1]}" )
+      if ENV['RACK_ENV'] == "development"
+        trace_logger.log("Elapsed: #{((Time.now - @tracer_bullet_start_time)*1000).to_i}ms #{caller(0)[1]}" )
         @tracer_bullet_start_time = Time.now
       end
     end
-    alias_method :tb, :tracer_bullet
-
-    private
-
-    def _tracer_bullets_log(msg)
-      log = Rails.logger
-      if defined?(ActiveSupport::TaggedLogging)
-        log.tagged("TracerBullets") { |l| l.debug(msg) }
-      else
-        log.debug(msg)
-      end
-    end
   end
-
-  module Controller
-    extend ActiveSupport::Concern
-    include Methods
-
-    included do
-      before_filter :setup_tracer_bullet_start_time
-    end
-
-    def setup_tracer_bullet_start_time
-      @tracer_bullet_start_time = Time.now
-    end
-
-  end
-
-  module View
-    extend ActiveSupport::Concern
-    include Methods
-  
-  end
-
-
-  class Railtie < Rails::Railtie
-    initializer "tracer_bullet.action_controller" do
-      ActiveSupport.on_load(:action_controller) do
-        include TracerBullets::Controller
-      end
-    end
-
-    initializer "tracer_bullet.action_view" do
-      ActiveSupport.on_load(:action_view) do
-        include TracerBullets::View
-      end
-    end
-  end
-
 end
+
+require 'tracer_bullets/railtie' if defined?(Rails)

--- a/lib/tracer_bullets/middleware.rb
+++ b/lib/tracer_bullets/middleware.rb
@@ -1,0 +1,18 @@
+require 'tracer_bullets'
+require 'tracer_bullets/trace_logger'
+
+module TracerBullets
+  class Middleware
+    include TracerMethods
+
+    def initialize(app)
+      @app = app
+      @app.class.send :include, TracerMethods
+    end
+
+    def call(env)
+      setup_tracer_bullet_start_time
+      @app.call(env)
+    end
+  end
+end

--- a/lib/tracer_bullets/railtie.rb
+++ b/lib/tracer_bullets/railtie.rb
@@ -1,0 +1,32 @@
+require 'tracer_bullets/trace_logger'
+require "active_support/concern"
+
+module TracerBullets
+  class Railtie < Rails::Railtie
+    initializer "tracer_bullet.action_controller" do
+      ActiveSupport.on_load(:action_controller) do
+        include TracerBullets::Controller
+      end
+    end
+
+    initializer "tracer_bullet.action_view" do
+      ActiveSupport.on_load(:action_view) do
+        include TracerBullets::View
+      end
+    end
+  end
+
+  module Controller
+    extend ActiveSupport::Concern
+    include TracerMethods
+
+    included do
+      before_filter :setup_tracer_bullet_start_time
+    end
+  end
+
+  module View
+    extend ActiveSupport::Concern
+    include TracerMethods
+  end
+end

--- a/lib/tracer_bullets/trace_logger.rb
+++ b/lib/tracer_bullets/trace_logger.rb
@@ -1,0 +1,32 @@
+module TracerBullets
+  class TraceLogger
+    extend Forwardable
+
+    def initialize(type)
+      @logger = type.new
+    end
+
+    def_delegators :@logger, :log
+  end
+
+  class RailsLogger
+    def initialize
+      @logger = Rails.logger
+    end
+
+    def log(msg)
+      if defined?(ActiveSupport::TaggedLogging)
+        @logger.tagged("TracerBullets") { |l| l.debug(msg) }
+      else
+        @logger.debug(msg)
+      end
+    end
+  end
+
+  class RackLogger
+    def log(msg)
+      puts msg
+    end
+  end
+end
+

--- a/tracer_bullets.gemspec
+++ b/tracer_bullets.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = TracerBullets::VERSION
   spec.authors       = ["nate"]
   spec.email         = ["nate@cityposh.com"]
-  spec.description   = %q{A simple way to see time expiration in your Rails log files}
-  spec.summary       = %q{A simple way to see time expiration in your Rails log files}
+  spec.description   = %q{A simple way to see time expiration in your Rails/Rack log files}
+  spec.summary       = %q{A simple way to see time expiration in your Rails/Rack log files}
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
Adding rack compatibility.

No changes should be required for use within Rails (please test).
To use with Rack, just add a `use TracerBullets::Middleware` directive before firing up the app. 

Updated documents with a more detailed description of how to setup for Rack.

I setup a dummy rails and rack app to test. I can commit those under an "examples" directory if wanted.
